### PR TITLE
Some fixes

### DIFF
--- a/logiq/default/app.conf
+++ b/logiq/default/app.conf
@@ -4,7 +4,7 @@
 is_configured = 1
 state_change_requires_restart = true
 build = 39
-install_source_checksum = c9cd0ca2e366f980f0545d28b4b19872138a9cc4
+install_source_checksum = 17653b001d39a0e5fcd0f3d40fe3ebf153e5af15
 
 [launcher]
 author = Bjorn Hovd

--- a/logiq/default/app.conf
+++ b/logiq/default/app.conf
@@ -3,17 +3,17 @@
 [install]
 is_configured = 1
 state_change_requires_restart = true
-build = 38
+build = 39
 install_source_checksum = c9cd0ca2e366f980f0545d28b4b19872138a9cc4
 
 [launcher]
 author = Bjorn Hovd
 description = Digital Guardian Diagnostic Log App
-version = 1.3.8
+version = 1.3.9
 
 [id]
 name = logiq
-version = 1.3.8
+version = 1.3.9
 
 [package]
 id = logiq

--- a/logiq/default/data/ui/views/aci_classification.xml
+++ b/logiq/default/data/ui/views/aci_classification.xml
@@ -49,17 +49,6 @@
       <default>*</default>
       <initialValue>*</initialValue>
     </input>
-    <input type="checkbox" token="timetok.earliest">
-      <label>Limit to last session for:</label>
-      <fieldForLabel>host</fieldForLabel>
-      <fieldForValue>sessionStartTime</fieldForValue>
-      <search>
-        <query>|savedsearch sessionStart hosttok=$hosttok|s$|head 1</query>
-        <earliest>0</earliest>
-        <latest></latest>
-      </search>
-      <delimiter> </delimiter>
-    </input>
     <input type="time" token="timetok" searchWhenChanged="true">
       <label>Time Range</label>
       <default>

--- a/logiq/default/data/ui/views/dg_log.xml
+++ b/logiq/default/data/ui/views/dg_log.xml
@@ -26,17 +26,6 @@
       <choice value="">ALL</choice>
       <default></default>
     </input>
-    <input type="checkbox" token="timetok.earliest">
-      <label>Limit to last session for:</label>
-      <fieldForLabel>host</fieldForLabel>
-      <fieldForValue>sessionStartTime</fieldForValue>
-      <search>
-        <query>|savedsearch sessionStart hosttok=$hosttok|s$|head 1</query>
-        <earliest>0</earliest>
-        <latest></latest>
-      </search>
-      <delimiter> </delimiter>
-    </input>
     <input type="time" token="timetok" searchWhenChanged="true">
       <label>Event Time</label>
       <default>

--- a/logiq/default/data/ui/views/dgagent.xml
+++ b/logiq/default/data/ui/views/dgagent.xml
@@ -14,17 +14,6 @@
       <choice value="*">All</choice>
       <default>*</default>
     </input>
-    <input type="checkbox" token="timetok.earliest">
-      <label>Limit to last session for:</label>
-      <fieldForLabel>host</fieldForLabel>
-      <fieldForValue>sessionStartTime</fieldForValue>
-      <search>
-        <query>|savedsearch sessionStart hosttok=$hosttok|s$|head 1</query>
-        <earliest>0</earliest>
-        <latest></latest>
-      </search>
-      <delimiter> </delimiter>
-    </input>
     <input type="time" token="timetok" searchWhenChanged="true">
       <label>Time Range</label>
       <default>

--- a/logiq/default/data/ui/views/dgwip.xml
+++ b/logiq/default/data/ui/views/dgwip.xml
@@ -37,17 +37,6 @@
         <latest></latest>
       </search>
     </input>
-    <input type="checkbox" token="timetok.earliest">
-      <label>Limit to last session for:</label>
-      <fieldForLabel>host</fieldForLabel>
-      <fieldForValue>sessionStartTime</fieldForValue>
-      <search>
-        <query>|savedsearch sessionStart hosttok=$hosttok|s$|head 1</query>
-        <earliest>0</earliest>
-        <latest></latest>
-      </search>
-      <delimiter> </delimiter>
-    </input>
     <input type="time" token="timetok" searchWhenChanged="true">
       <label>Time Selection</label>
       <default>
@@ -90,7 +79,7 @@
         <option name="refresh.display">progressbar</option>
         <option name="rowNumbers">false</option>
         <option name="totalsRow">false</option>
-        <option name="wrap">true</option>
+        <option name="wrap">false</option>
         <drilldown>
           <link target="_blank">search?q=index%3Dlogiq%20sourcetype%3Ddgwip%20host%3D$hosttok$%20skip%3D%22$click.value$%22%20%22$click.name2$%22%3D%22$click.value2$*%22&amp;earliest=0&amp;latest=</link>
         </drilldown>
@@ -122,7 +111,7 @@
           <latest>$timetok.latest$</latest>
         </search>
         <option name="drilldown">none</option>
-        <option name="refresh.display">progressbar</option>
+        <option name="wrap">false</option>
       </table>
     </panel>
   </row>
@@ -139,6 +128,7 @@
         <option name="dataOverlayMode">none</option>
         <option name="drilldown">none</option>
         <option name="refresh.display">progressbar</option>
+        <option name="wrap">false</option>
       </table>
     </panel>
   </row>

--- a/logiq/default/data/ui/views/process_flags.xml
+++ b/logiq/default/data/ui/views/process_flags.xml
@@ -42,15 +42,6 @@
       <choice value="">All</choice>
       <default></default>
     </input>
-    <input type="checkbox" token="timetok.earliest">
-      <label>Limit to last session for:</label>
-      <delimiter> </delimiter>
-      <fieldForLabel>host</fieldForLabel>
-      <fieldForValue>sessionStartTime</fieldForValue>
-      <search>
-        <query>|savedsearch sessionStart hosttok=$hosttok|s$|head 1</query>
-      </search>
-    </input>
     <input type="time" token="timetok" searchWhenChanged="true">
       <label>Time Range</label>
       <default>

--- a/logiq/default/data/ui/views/proservaci.xml
+++ b/logiq/default/data/ui/views/proservaci.xml
@@ -13,17 +13,6 @@
       <choice value="*">All</choice>
       <default>*</default>
     </input>
-    <input type="checkbox" token="timetok.earliest">
-      <label>Limit to last session for:</label>
-      <fieldForLabel>host</fieldForLabel>
-      <fieldForValue>sessionStartTime</fieldForValue>
-      <search>
-        <query>|savedsearch sessionStart hosttok=$hosttok|s$|head 1</query>
-        <earliest>0</earliest>
-        <latest></latest>
-      </search>
-      <delimiter> </delimiter>
-    </input>
     <input type="time" token="timetok" searchWhenChanged="true">
       <label>Time Range</label>
       <default>

--- a/logiq/default/data/ui/views/rule_debug.xml
+++ b/logiq/default/data/ui/views/rule_debug.xml
@@ -32,17 +32,6 @@
       <default>*</default>
       <initialValue>*</initialValue>
     </input>
-    <input type="checkbox" token="timetok.earliest">
-      <label>Limit to last session for:</label>
-      <fieldForLabel>host</fieldForLabel>
-      <fieldForValue>sessionStartTime</fieldForValue>
-      <search>
-        <query>|savedsearch sessionStart hosttok=$hosttok|s$|head 1</query>
-        <earliest>0</earliest>
-        <latest></latest>
-      </search>
-      <delimiter> </delimiter>
-    </input>
     <input type="time" token="timetok" searchWhenChanged="true">
       <label>Time Range</label>
       <default>

--- a/logiq/default/data/ui/views/sys_info.xml
+++ b/logiq/default/data/ui/views/sys_info.xml
@@ -20,7 +20,7 @@
       <table>
         <title>System Information</title>
         <search>
-          <query>index=logiq host=$hosttok|s$ sourcetype=DIAG06 systemUptime=* OR systemBuild=* OR productVersion=* OR kernelVersion=*|rex field=systemUptime mode=sed "s/(\d+) days? (\d+) hours? (\d+) minutes? (\d+) seconds?/\1+\2:\3:\4/g"|eval Time=strftime(_time, "%Y-%m-%d %H:%M:%S.%3N")|convert dur2sec(systemUptime)|eval sessionStartTime=_time-systemUptime|eval readableSessionTime=strftime(sessionStartTime, "%Y-%m-%d %H:%M:%S.%3N")|table Time,host,kernelVersion,productVersion,systemBuild,readableSessionTime|stats values(*) as * by host|rename Time as "Diagnostic Time" host AS Host kernelVersion AS Windows productVersion AS Version systemBuild AS Build readableSessionTime AS "Last session start"|table Host,Windows,Version,Build,"Diagnostic Time","Last session start"</query>
+          <query>index=logiq host=$hosttok|s$ sourcetype=DIAG06 systemUptime=* OR systemBuild=* OR productVersion=* OR kernelVersion=*|rex field=systemUptime mode=sed "s/(\d+) days? (\d+) hours? (\d+) minutes? (\d+) seconds?/\1+\2:\3:\4/g"|eval Time=strftime(_time, "%Y-%m-%dT%H:%M:%S.%3N")|convert dur2sec(systemUptime)|eval sessionStartTime=_time-systemUptime|eval readableSessionTime=strftime(sessionStartTime, "%Y-%m-%dT%H:%M:%S.%3N")|table Time,host,kernelVersion,productVersion,systemBuild,readableSessionTime|stats values(*) as * by host|rename Time as "Diagnostic Time" host AS Host kernelVersion AS Windows productVersion AS Version systemBuild AS Build readableSessionTime AS "Last session start"|table Host,Windows,Version,Build,"Diagnostic Time","Last session start"</query>
           <earliest>0</earliest>
           <latest></latest>
         </search>

--- a/logiq/default/sysinfodatetime.xml
+++ b/logiq/default/sysinfodatetime.xml
@@ -2,10 +2,15 @@
     <define name="sysinfo_datetime" extract="year,month,day,hour,minute,second">
         <text><![CDATA[^\s*ENVIRONMENT INFORMATION FROM [^ ]+ ON\s(\d{4})-(\d{2})-(\d{2}) AT (\d{2}):(\d{2}):(\d{2})]]></text>
     </define>
+    <define name="sysinfo_usdatetime" extract="month,day,year,hour,minute,second,ampm">
+        <text><![CDATA[^\s*ENVIRONMENT INFORMATION FROM [^ ]+ ON\s(\d{1,2})\/(\d{1,2})\/(\d{4}) AT (\d{1,2}):(\d{1,2}):(\d{1,2}) ([AP]M)]]></text>
+    </define>
     <timePatterns>
       <use name="sysinfo_datetime"/> 
+	  <use name="sysinfo_usdatetime"/>
     </timePatterns>
     <datePatterns>
       <use name="sysinfo_datetime"/> 
+	  <use name="sysinfo_usdatetime"/>
     </datePatterns>
 </datetime>

--- a/logiq/metadata/local.meta
+++ b/logiq/metadata/local.meta
@@ -41,7 +41,7 @@ access = read : [ * ], write : [ admin ]
 export = none
 owner = admin
 version = 8.1.3
-modtime = 1616685115.029726000
+modtime = 1616697322.910095000
 
 [views/applications_installed]
 access = read : [ * ], write : [ admin ]
@@ -91,7 +91,7 @@ modtime = 1615503582.428364000
 [views/process_flags]
 owner = admin
 version = 8.1.3
-modtime = 1616592312.354272000
+modtime = 1616697354.649497000
 
 [props/dglog/EXTRACT-processFlags]
 access = read : [ * ], write : [ admin ]
@@ -129,7 +129,7 @@ access = read : [ * ], write : [ admin ]
 export = none
 owner = admin
 version = 8.1.3
-modtime = 1616460412.043205000
+modtime = 1616697365.368667000
 
 [props/prcsflgs/EXTRACT-process%2CprocessFlags%2Ccompany]
 access = read : [ * ], write : [ admin ]
@@ -170,7 +170,7 @@ modtime = 1613778398.630440000
 
 [app/install/install_source_checksum]
 version = 8.1.3
-modtime = 1616677958.509073000
+modtime = 1616690668.416210000
 
 [inputs/monitor%3A%2F%2F%2Flogiq%2F%2A%2FDIAG07-HW_INFO.LOG]
 version = 8.1.2
@@ -254,7 +254,7 @@ modtime = 1614221481.631209000
 [views/aci_classification]
 owner = admin
 version = 8.1.3
-modtime = 1616460309.884146000
+modtime = 1616697470.209462000
 
 [props/dglog/EXTRACT-entity%2Cfrequency]
 access = read : [ * ], write : [ admin, power ]
@@ -290,7 +290,7 @@ modtime = 1615427839.121232000
 [views/rule_debug]
 owner = admin
 version = 8.1.3
-modtime = 1616460896.602795000
+modtime = 1616697483.558849000
 
 [props/dglog/EXTRACT-dglog%20%3A%20EXTRACT-ruleVarAction%2CruleVarName%2CruleVarType%2CruleVarScope%2CruleVarValue]
 access = read : [ * ], write : [ admin, power ]
@@ -328,12 +328,12 @@ modtime = 1614719326.998611000
 [views/dgagent]
 owner = admin
 version = 8.1.3
-modtime = 1616460160.682791000
+modtime = 1616697509.549032000
 
 [views/proservaci]
 owner = admin
 version = 8.1.3
-modtime = 1616460095.073329000
+modtime = 1616697498.669090000
 
 [views/compare_config]
 owner = admin
@@ -387,7 +387,7 @@ access = read : [ * ], write : [ admin, power ]
 export = none
 owner = admin
 version = 8.1.3
-modtime = 1616460595.933223000
+modtime = 1616697215.898477000
 
 [props/DIAG06]
 owner = admin


### PR DESCRIPTION
Added system info time extraction for US time format
Removed the checkbox to pick session time range (it doe snot work properly)  Instead, copy the session start time manually into the time range picker control.